### PR TITLE
fix: ignore ConnectionAbortedError in receive

### DIFF
--- a/zcached/__init__.py
+++ b/zcached/__init__.py
@@ -19,7 +19,7 @@ __all__: Final[Tuple[str, ...]] = (
     "Deserializer",
     "Reader",
     "Errors",
-    "__version__"
+    "__version__",
 )
 
 __version__: Final[str] = "1.1.1"

--- a/zcached/connection.py
+++ b/zcached/connection.py
@@ -128,7 +128,7 @@ class Connection:
         try:
             data: bytes = self.socket.recv(self.buff_size)
             logging.debug("Received a response -> %s", data)
-        except BlockingIOError:
+        except (BlockingIOError, ConnectionAbortedError):
             return None
 
         return data


### PR DESCRIPTION
## Summary

- [x] I have tested my changes.

### What is this pull request for?
Sometimes while using the client, when the server shuts down, the client may receive a ConnectionAbortedError. However, the client should return Error enum.
